### PR TITLE
Update __init__.py openid赋值错误

### DIFF
--- a/wxpay/wxpay/__init__.py
+++ b/wxpay/wxpay/__init__.py
@@ -91,7 +91,8 @@ class WXpay(object):
         if trade_type == 'JSAPI' and openid is None:
             raise MissingParameter(u'JSAPI必须传入openid')
         else:
-            post_dict['openid'] = openid
+            if openid is not None:
+                post_dict['openid'] = openid
         post_dict['sign'] = self.generate_sign(post_dict)
         ret_xml = dict2xml(post_dict, wrap='xml')
 


### PR DESCRIPTION
 if trade_type == 'JSAPI' and openid is None:
这一行逻辑有误，如果 trade_type 是 NATIVE openid是None，post_dict['openid'] = openid 这个赋值语句被执行，结果openid传过去的是一个‘None’，微信服务器返回错误 “无效的openid”
